### PR TITLE
Replaced runner image with standard CircleCI php image.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ aliases:
   # Make sure to replace the fingerprint value below with your own.
   - &deploy_ssh_fingerprint "2d:71:4d:aa:4d:34:38:b5:8f:af:ca:3b:d4:82:6a:21"
   - &container_config
-    working_directory: /app
+    working_directory: ~/project
     docker:
-      - image: amazeeio/php:7.2-cli-drupal
+      - image: circleci/php:7.2.11-cli-browsers
     environment:
       DEPLOY_SSH_FINGERPRINT: *deploy_ssh_fingerprint
 
@@ -14,6 +14,7 @@ jobs:
     <<: *container_config
     steps:
       - checkout
+      - run: sudo -E apt-get update && sudo -E apt-get install -y libfreetype6-dev libjpeg62-turbo-dev libpng-dev && sudo -E docker-php-ext-install -j$(nproc) iconv && sudo -E docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && sudo -E docker-php-ext-install -j$(nproc) gd
       - run: .circleci/build.sh
       - run: .circleci/test.sh
       - run:

--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -28,7 +28,7 @@ DEPLOY_PROCEED="${DEPLOY_PROCEED:-0}"
 [ -z "${DEPLOY_REMOTE}" ] && echo "ERROR: Missing required value for DEPLOY_REMOTE" && exit 1
 [ -z "${DEPLOY_SSH_FINGERPRINT}" ] && echo "ERROR: Missing required value for DEPLOY_SSH_FINGERPRINT" && exit 1
 
-[ "${DEPLOY_PROCEED}" == "0" ] && echo "==> Skipping deployment" && exit 0
+[ "${DEPLOY_PROCEED}" != "1" ] && echo "==> Skipping deployment because \$DEPLOY_PROCEED is not set to 1" && exit 0
 
 # Configure git and SSH to connect to remote servers for deployment.
 mkdir -p "${HOME}/.ssh/"


### PR DESCRIPTION
- Replaced Amazee's container, used as CI runner, with standard CircleCI's container due to the fact that Amazee container image has a SSH key in a file, which breaks how CircleCI checks out code.
- Updated `$DEPLOY_PROCEED` condition to trigger only when it's value is set to `1`.